### PR TITLE
Small improvements for setup.py, add warning if hex file is used

### DIFF
--- a/ch55xtool/ch55xtool.py
+++ b/ch55xtool/ch55xtool.py
@@ -348,7 +348,7 @@ def main():
         '--file',
         type=str,
         default='',
-        help="The target file to be flashed.")
+        help="The target file to be flashed. This must be a binary file (hex files are not supported).")
     parser.add_argument(
         '-r',
         '--reset_after_flash',
@@ -380,6 +380,8 @@ def main():
 
     if args.file != '':
         payload = list(open(args.file, 'rb').read())
+        if args.file.endswith('.hex') or args.file.endswith('.ihx') or payload[0]==58:
+            print("WARNING: This looks like a hex file. This tool only supports binary files.")
         if ret[0] in ['V2.30']:
             ret = __write_key_ch55x_v20(dev, chk_sum)
             if ret is None:

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,4 @@ setuptools.setup(
         ]
     },
     python_requires='>=3.5',
-    install_requires=['pyusb>=1.1.0'])
+    install_requires=['pyusb>=1.0.0'])

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,10 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    entry_points = {
+        'console_scripts': [
+            'ch55xtool = ch55xtool.ch55xtool:main'
+        ]
+    },
     python_requires='>=3.5',
     install_requires=['pyusb>=1.1.0'])


### PR DESCRIPTION
This pull request adds three small improvements. I can split it if you prefer that:

1. Add entry point to setup.py. This will add a `ch55xtool` script to PATH.
2. Downgrade requirement to pyusb 1.0. My system doesn't have version 1.1 but it works fine with 1.0, so I don't think we actually need 1.1.
3. Add a warning if a hex file is used.